### PR TITLE
gloriously fail on non-zero exit code

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set +e
+
 clear
 
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"


### PR DESCRIPTION
For example, if `brew doctor` fails this script will continue on.