### PR TITLE
Install rowanj-gitx instead of regular gitx

### DIFF
--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -5,7 +5,7 @@ brew tap git-duet/tap
 brew install git-duet
 brew install git-pair
 brew cask install github-desktop
-brew cask install gitx
+brew cask install rowanj-gitx
 brew cask install sourcetree
 
 echo


### PR DESCRIPTION
rowanj's GitX-dev fork is more well-maintained than the original GitX, and has several
improved features.

https://rowanj.github.io/gitx/