### PR TITLE
Make OSX configuration work for users who aren't named 'pivotal'

### DIFF
--- a/scripts/configuration-osx.sh
+++ b/scripts/configuration-osx.sh
@@ -11,8 +11,8 @@ defaults write com.apple.dock autohide -bool true
 killall Dock
 
 # fast key repeat rate, requires reboot to take effect
-defaults write /Users/pivotal/Library/Preferences/.GlobalPreferences KeyRepeat -int 1
-defaults write /Users/pivotal/Library/Preferences/.GlobalPreferences InitialKeyRepeat -int 15
+defaults write /Users/$(whoami)/Library/Preferences/.GlobalPreferences KeyRepeat -int 1
+defaults write /Users/$(whoami)/Library/Preferences/.GlobalPreferences InitialKeyRepeat -int 15
 
 # set finder to display full path in title bar
 defaults write com.apple.finder '_FXShowPosixPathInTitle' -bool true
@@ -22,4 +22,4 @@ defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true
 #to revert use defaults -currentHost delete com.apple.ImageCapture disableHotPlug
 
 # enable Flycut to start on login
-defaults write '/Users/pivotal/Library/Application Support/Flycut/com.generalarcade.flycut.plist' loadOnStartup -bool true
+defaults write "/Users/$(whoami)/Library/Application Support/Flycut/com.generalarcade.flycut.plist" loadOnStartup -bool true


### PR DESCRIPTION
I tried to run workstation-setup on my Mac at home, and this was the only real hiccup I ran into.