### PR TITLE
Use default setting for `push.default` in Git

### DIFF
--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -15,5 +15,4 @@ cp files/.pairs ~/.pairs
 echo
 echo "Setting global Git configurations"
 git config --global core.editor /usr/bin/vim
-git config --global push.default matching
 git config --global transfer.fsckobjects true


### PR DESCRIPTION
The default behavior of modern Git versions is to only push the current branch when running `git push`.

This removes a line that was instead setting us up on the previous behavior of pushing all branches with matching names.