### PR TITLE
add ag (Silver Searcher) to engineering apps

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -5,6 +5,7 @@ pairs:
   de: David Edwards; dedwards
   ec: Eric Cipra; ecipra
   ts: Todd Sedano; tsedano
+  sw: Stephen Wu; stwu
 
 email:
   prefix: pair

--- a/scripts/applications-common.sh
+++ b/scripts/applications-common.sh
@@ -9,6 +9,7 @@ brew cask install shiftit
 brew cask install dash
 brew cask install postman
 brew cask install google-drive
+brew install the_silver_searcher
 
 # Terminals
 


### PR DESCRIPTION
Not sure what the process is for determining/requesting what goes into this repository, but a number of devs here like using `ag` as an alternative to `grep` and `find`.  Totally cool with this making it in or not.

https://github.com/ggreer/the_silver_searcher