### PR TITLE
Add then to fix syntax error in if statement

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -36,6 +36,7 @@ then
 fi
 
 if [ "${SETUP_TYPE}" == "data-engineer" ]
+then
   source ${MY_DIR}/applications-data-engineer.sh
 fi
 


### PR DESCRIPTION
Adds the missing 'then' keyword to fix syntax error

```
if [ conditional expression ]
then
	statement1
	statement2
	.
fi
```