### PR TITLE
Enable bash tab completion for ssh

### DIFF
--- a/scripts/configuration-bash.sh
+++ b/scripts/configuration-bash.sh
@@ -13,3 +13,4 @@ source ~/.bash_profile
 bash-it enable completion git
 bash-it enable plugin ssh
 bash-it enable plugin rbenv
+bash-it enable completion ssh


### PR DESCRIPTION
- it will scan ~/.ssh/config, ~.ssh/known_host, and /etc/hosts