### PR TITLE
Install MacVim from cask

### DIFF
--- a/scripts/applications-common.sh
+++ b/scripts/applications-common.sh
@@ -35,7 +35,7 @@ brew cask install skype
 brew cask install macdown
 brew cask install sublime-text
 brew cask install textmate
-brew install macvim
+brew cask install macvim
 
 # Emulation tools
 


### PR DESCRIPTION
Lately, MacVim from the cask has been good enough and it's easier to install without requiring XCode.

Any objections?