### PR TITLE
Remove accessibility autoconfiguation for ShiftIt

### DIFF
--- a/scripts/configurations.sh
+++ b/scripts/configurations.sh
@@ -1,6 +1,5 @@
 echo
 # prereqs
-brew install tccutil
 brew tap OJFord/formulae
 brew install loginitems
 
@@ -8,7 +7,6 @@ echo "Configuring iTerm"
 cp files/com.googlecode.iterm2.plist ~/Library/Preferences
 
 echo "Configuring ShiftIt"
-sudo tccutil --insert "org.shiftitapp.ShiftIt" # Enable Accessibility Settings
 loginitems -a "ShiftIt" # Start on login
 open /Applications/ShiftIt.app
 


### PR DESCRIPTION
It doesn't work anymore in macOS Sierra

See #94 