### PR TITLE
Remove nexus and jenkins from java.sh

### DIFF
--- a/scripts/java.sh
+++ b/scripts/java.sh
@@ -4,6 +4,4 @@ brew cask install java
 brew cask install intellij-idea
 brew install maven
 brew install gradle
-brew install nexus
-brew install jenkins
 brew install springboot


### PR DESCRIPTION
Projects generally don't need these tools locally while developing.

If someone wants these, you should add them via a Brewfile or something
else specific to your project.

Signed-off-by: Grant Hutchins <ghutchins@pivotal.io>