### PR TITLE
No longer set GOPATH

### DIFF
--- a/scripts/applications-data-engineer.sh
+++ b/scripts/applications-data-engineer.sh
@@ -7,9 +7,6 @@ brew install wget
 # Go source
 mkdir -p ~/go/src
 brew install go --cross-compile-common
-export GOPATH=$HOME/go
-echo "Adding GOPATH"
-echo 'export GOPATH==$HOME/go' >> ~/.bash_profile
 
 # C tools
 brew install ccache


### PR DESCRIPTION
`brew install go` (above) will always install golang 1.8+, and the
default behavior starting with that version is as this code was setting.