### PR TITLE
Install rbenv before bash-it uses it

### DIFF
--- a/scripts/configuration-bash.sh
+++ b/scripts/configuration-bash.sh
@@ -2,6 +2,7 @@ echo
 echo "Configuring bash with bash-it"
 brew install grc
 brew install coreutils
+brew install rbenv
 brew install watch
 cp files/dircolors.ansi-dark ~/.dircolors
 cp files/.inputrc ~/.inputrc

--- a/scripts/ruby.sh
+++ b/scripts/ruby.sh
@@ -2,7 +2,6 @@ echo
 echo "Installing Ruby tools and Ruby 2.3.1"
 cp files/.irbrc ~/.irbrc
 brew install readline
-brew install rbenv
 eval "$(rbenv init -)"
 rbenv install 2.3.1 --skip-existing
 rbenv global 2.3.1


### PR DESCRIPTION
The script configuration-bash.sh enabled the rbenv plugin on bash-it.
This change guarantees that it is installed before this happens.

Previously, rbenv would be installed as a later step in the lab-engineer
script which would call ruby.sh. But for the data-engineer script this
did not happen.