### PR TITLE
Remove `brew doctor`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ In addition to the Engineering applications, this script also installs the list 
 
 If you're having problems using the setup script, please let us know by [opening an issue](https://github.com/pivotal/workstation-setup/issues/new).
 
+If you see errors from `brew`, try running `brew doctor` and include the diagnostic output in your issue submission.
+
 ## Customizing
 
 If you'd like to customize this project for a project's use:

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -11,10 +11,6 @@ echo
 echo "Ensuring you have the latest Homebrew..."
 brew update
 
-echo 
-echo "Ensuring you have a healthy Homebrew environment..."
-brew doctor
-
 echo
 echo "Ensuring your Homebrew directory is writable..."
 sudo chown -R $(whoami) /usr/local/bin


### PR DESCRIPTION
- It fails on El Capitan because it demands the latest version
  of Xcode, which El Capitan can't run.
- Since workstation-setup is usually run on a fresh install of the
  OS, we think it's unlikely that brew doctor will detect real problems
  for most users. Users who do run into problems can run `brew doctor`
  themselves.