### PR TITLE
Fix markdown links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you're setting up an engineering machine run one or both of the following:
 ./labs-engineer.sh
 ```
 
-The list of Engineering applications is found in: [applications-common.sh] (https://github.com/pivotal/workstation-setup/blob/master/scripts/applications-common.sh)
+The list of Engineering applications is found in: [applications-common.sh](https://github.com/pivotal/workstation-setup/blob/master/scripts/applications-common.sh)
 
 ### Designer Machine
 
@@ -54,7 +54,7 @@ If you're setting up a design machine run the following:
 ./designer.sh
 ```
 
-In addition to the Engineering applications, this script also installs the list of Design applications found in: [applications-designer.sh]  (https://github.com/pivotal/workstation-setup/blob/master/scripts/applications-designer.sh)
+In addition to the Engineering applications, this script also installs the list of Design applications found in: [applications-designer.sh](https://github.com/pivotal/workstation-setup/blob/master/scripts/applications-designer.sh)
 
 ## Having problems?
 


### PR DESCRIPTION
Current:
![workstation-setup-links](https://user-images.githubusercontent.com/2067379/27355574-89bdd66a-55d9-11e7-9add-ae568d685019.png)

Suggested Change:
![workstation-setup-links-suggestion](https://user-images.githubusercontent.com/2067379/27355670-e34cc7d6-55d9-11e7-9057-8e1102048ea0.png)
