### PR TITLE
Enable people to communicate with zoom desktop client

### DIFF
--- a/scripts/applications-common.sh
+++ b/scripts/applications-common.sh
@@ -29,6 +29,7 @@ brew cask install firefox
 brew cask install slack
 brew cask install screenhero
 brew cask install skype
+brew cask install zoomus
 
 # Text Editors
 


### PR DESCRIPTION
zoomus is the name of the cask because zoom was already taken and their
url is zoom.us

→ brew cask info zoomus
zoomus: 4.0.29656.0413
https://www.zoom.us/
Not installed
From: https://github.com/caskroom/homebrew-cask/blob/master/Casks/zoomus.rb
==> Name
Zoom.us
==> Artifacts
zoomusInstaller.pkg (pkg)