### PR TITLE
Install Gogland

### DIFF
--- a/scripts/applications-data-engineer.sh
+++ b/scripts/applications-data-engineer.sh
@@ -5,12 +5,7 @@ brew install autoconf
 brew install wget
 brew install fzf
 
-# Go source
-mkdir -p ~/go/src
-brew install go --cross-compile-common
-export GOPATH=$HOME/go
-echo "Adding GOPATH"
-echo 'export GOPATH==$HOME/go' >> ~/.bash_profile
+source ${MY_DIR}/golang.sh
 
 # C tools
 brew install ccache

--- a/scripts/golang.sh
+++ b/scripts/golang.sh
@@ -3,8 +3,4 @@ echo "Installing Golang Development tools"
 
 mkdir -p ~/go/src
 brew install go --cross-compile-common
-export GOPATH=$HOME/go
-echo "Adding GOPATH"
-echo 'export GOPATH==$HOME/go' >> ~/.bash_profile
-
 brew cask install gogland

--- a/scripts/golang.sh
+++ b/scripts/golang.sh
@@ -4,3 +4,13 @@ echo "Installing Golang Development tools"
 mkdir -p ~/go/src
 brew install go --cross-compile-common
 brew cask install gogland
+
+echo
+echo "Setting up Gogland preferences from pivotal_ide_prefs..."
+pushd ~/workspace
+rm -rf pivotal_ide_prefs
+git clone https://github.com/pivotal/pivotal_ide_prefs.git
+pushd pivotal_ide_prefs/cli/
+./bin/ide_prefs install --ide=gogland
+popd
+popd

--- a/scripts/golang.sh
+++ b/scripts/golang.sh
@@ -1,0 +1,10 @@
+echo
+echo "Installing Golang Development tools"
+
+mkdir -p ~/go/src
+brew install go --cross-compile-common
+export GOPATH=$HOME/go
+echo "Adding GOPATH"
+echo 'export GOPATH==$HOME/go' >> ~/.bash_profile
+
+brew cask install gogland


### PR DESCRIPTION
The scripts used to do setup for golang, but didn't install Gogland. This
commit installs Gogland and does the setup in the same script.

Signed-off-by: C.J. Jameson <cjameson@pivotal.io>