### PR TITLE
Removes --cross-compile-common flag from go

### DIFF
--- a/scripts/golang.sh
+++ b/scripts/golang.sh
@@ -2,7 +2,7 @@ echo
 echo "Installing Golang Development tools"
 
 mkdir -p ~/go/src
-brew install go --cross-compile-common
+brew install go
 brew cask install gogland
 
 echo


### PR DESCRIPTION
I tested with 1) brew uninstall go, 2) brew install go, 3) run tests and build gpbackup

Solves https://github.com/pivotal/workstation-setup/issues/105