### PR TITLE
Fix vim config to not crash the setup

### DIFF
--- a/scripts/configurations.sh
+++ b/scripts/configurations.sh
@@ -19,8 +19,8 @@ echo "Installing vim configuration"
 pushd ~/
 if [ ! -d ~/.vim ]; then
     git clone https://github.com/pivotal/vim-config.git ~/.vim
+    ~/.vim/bin/install
 fi
-~/.vim/bin/install
 popd
 
 echo


### PR DESCRIPTION
This fixes #126, an issue with the vim configuration part of the setup where it would crash if the directory `~/.vim` already existed and the file `~/.vim/bin/install` was not there. 