### PR TITLE
Provides hints on how to set hostname when script finishes

### DIFF
--- a/scripts/finished.sh
+++ b/scripts/finished.sh
@@ -1,5 +1,13 @@
 echo
+echo "-----------------------------------------"
 echo "Done!"
+echo "-----------------------------------------"
+
+echo
+echo "If hostname needs to be set consider"
+echo "sudo scutil --set ComputerName newname"
+echo "sudo scutil --set LocalHostName newname"
+echo "sudo scutil --set HostName newname"
 
 echo
 echo "After checking the above output for any problems, start a new iTerm session to make use of all the tools that have been installed."


### PR DESCRIPTION
When imaging a new machine, the bootstrap gives us a window of opportunity to set the machine name. If we miss this window of opportunity, I'm often googling on how to set the hostname. This provides a quick reminder when the script ends.