### PR TITLE
Install bosh cli bosh-init bbl

### DIFF
--- a/scripts/cloud.sh
+++ b/scripts/cloud.sh
@@ -1,4 +1,5 @@
 echo
 echo "Installing Cloud Foundry Command-line Interface"
 brew tap cloudfoundry/tap
-brew install cf-cli
+brew install cf-cli bosh-cli bosh-init bbl
+ln -s /usr/local/bin/bosh2 /usr/local/bin/bosh


### PR DESCRIPTION
The only package we don't install from cloudfoundry
homebrew tap is 'credhub-cli'

Signed-off-by: Goutam Tadi <gtadi@pivotal.io>