### PR TITLE
Improve installation of bosh cli utils

### DIFF
--- a/scripts/cloud.sh
+++ b/scripts/cloud.sh
@@ -1,5 +1,6 @@
 echo
 echo "Installing Cloud Foundry Command-line Interface"
 brew tap cloudfoundry/tap
-brew install cf-cli bosh-cli bosh-init bbl
-ln -s /usr/local/bin/bosh2 /usr/local/bin/bosh
+brew install cf-cli
+brew install bosh-cli --without-bosh2
+brew install bbl


### PR DESCRIPTION
From #134 
https://github.com/pivotal/workstation-setup/pull/134#issuecomment-319862173

You shouldn't need bosh-init any more, as bosh-cli subsumes all features of
bosh-init
if you really want it to be called "bosh", it's just a
`brew install bosh-cli --without-bosh2` away.

Signed-off-by: Jesse Zhang <jzhang@pivotal.io>