### PR TITLE
Remove google drive from common applications

### DIFF
--- a/scripts/applications-common.sh
+++ b/scripts/applications-common.sh
@@ -12,7 +12,6 @@ brew cask install flycut
 brew cask install shiftit
 brew cask install dash
 brew cask install postman
-brew cask install google-drive
 brew install the_silver_searcher
 
 # Terminals


### PR DESCRIPTION
A cask for google drive currently does not exist so removing installation for now.