### PR TITLE
Remove loginitems from configurations script

### DIFF
--- a/scripts/configurations.sh
+++ b/scripts/configurations.sh
@@ -1,17 +1,11 @@
 echo
-# prereqs
-brew tap OJFord/formulae
-brew install loginitems
-
 echo "Configuring iTerm"
 cp files/com.googlecode.iterm2.plist ~/Library/Preferences
 
 echo "Configuring ShiftIt"
-loginitems -a "ShiftIt" # Start on login
 open /Applications/ShiftIt.app
 
 echo "Configuring FlyCut"
-loginitems -a "Flycut" # Start at login
 open /Applications/Flycut.app
 
 echo


### PR DESCRIPTION
This error is causing the config script to break. It has been an issue since at least July 24:
https://github.com/pivotal/workstation-setup/issues/133

perhaps loginitems should be removed for now?

![screen shot 2017-08-21 at 5 25 04 am](https://user-images.githubusercontent.com/2067379/29672178-81794332-88b9-11e7-8fde-8f01613e2c74.png)
