### PR TITLE
Removes Xcode dependency for macOS Sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project does not aim to do everything. Some examples:
 ## Getting Started
 
 - Make sure you are running the lastest version of macOS. (Currently [Sierra](https://www.apple.com/macos/sierra/))
-- Install the latest version of [Xcode](https://developer.apple.com/xcode/).
+- If you are not on Sierra, you need to install the latest version of [Xcode](https://developer.apple.com/xcode/). On Sierra, using git will install the command line developer tools.  
 
 Open up Terminal.app and run the following commands:
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,8 +15,6 @@ clear
 echo
 echo "Setting up a '$SETUP_TYPE' machine..."
 
-source ${MY_DIR}/xcode-license.sh
-
 # Note: Homebrew needs to be set up first
 source ${MY_DIR}/homebrew.sh
 source ${MY_DIR}/configuration-osx.sh

--- a/scripts/xcode-license.sh
+++ b/scripts/xcode-license.sh
@@ -1,4 +1,0 @@
-echo
-echo "Accepting the XCode Software License Agreement"
-echo
-sudo xcodebuild -license accept


### PR DESCRIPTION
On Sierra, when using git for the first time, it installs the developer tools

Solves https://github.com/pivotal/workstation-setup/issues/113