### PR TITLE
Guard against pre-installed rubymine

### DIFF
--- a/scripts/ruby.sh
+++ b/scripts/ruby.sh
@@ -9,9 +9,7 @@ gem install bundler
 rbenv rehash
 
 # guard against pre-installed rubymine
-if [ ! -e /Applications/RubyMine.app ]; then
-  brew cask install rubymine
-fi
+brew cask install rubymine --force
 
 source ${MY_DIR}/download-pivotal-ide-prefs.sh
 pushd ~/workspace/pivotal_ide_prefs/cli

--- a/scripts/ruby.sh
+++ b/scripts/ruby.sh
@@ -8,7 +8,10 @@ rbenv global 2.3.1
 gem install bundler
 rbenv rehash
 
-brew cask install rubymine
+# guard against pre-installed rubymine
+if [ ! -e /Applications/RubyMine.app ]; then
+  brew cask install rubymine
+fi
 
 source ${MY_DIR}/download-pivotal-ide-prefs.sh
 pushd ~/workspace/pivotal_ide_prefs/cli


### PR DESCRIPTION
Fixed bug:  If rubymine comes preinstalled, the script would crash.  