### PR TITLE
Add bash_it enabled directory

### DIFF
--- a/scripts/git-aliases.sh
+++ b/scripts/git-aliases.sh
@@ -18,6 +18,7 @@ git config --global alias.fixup commit --fixup
 git config --global alias.squash commit --squash
 git config --global alias.unstage reset HEAD
 git config --global alias.rum "rebase master@{u}"
+mkdir ~/.bash_it/aliases/enabled
 echo "#Git" >> ~/.bash_it/aliases/enabled/general.aliases.bash
 echo "alias gst='git status'" >> ~/.bash_it/aliases/enabled/general.aliases.bash
 


### PR DESCRIPTION
This is necessary for macOS High Sierra.

I'm not sure why this changed in High Sierra. 

Is this the best way to solve this?