### PR TITLE
Rename `github-desktop` cask to `github`.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -20,7 +20,7 @@ source ${MY_DIR}/homebrew.sh
 
 # Place any applications that require the user to type in their password here
 brew tap caskroom/cask
-brew cask install github-desktop
+brew cask install github
 brew cask install virtualbox
 brew cask install zoomus
 


### PR DESCRIPTION
- This is in response to the PR done [here](https://github.com/caskroom/homebrew-cask/pull/39883).