### PR TITLE
install protobufs with golang

### DIFF
--- a/scripts/golang.sh
+++ b/scripts/golang.sh
@@ -4,6 +4,7 @@ echo "Installing Golang Development tools"
 mkdir -p ~/go/src
 brew install go
 brew cask install gogland
+brew install protobuf
 
 source ${MY_DIR}/download-pivotal-ide-prefs.sh
 pushd ~/workspace/pivotal_ide_prefs/cli


### PR DESCRIPTION
I might recommend rejecting this...

 - Protobufs are specifically built for a variety of languages, not just golang
 - Not necessarily widely used
 - Some projects check in compiled *.proto code so that hackers don't need to compile the protobufs themselves
 - Other projects would help you install it (rather than expecting it to be part of workstation setup)

But wanted to throw this out there