### PR TITLE
Update links to applications-common.sh and applications-designer.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you're setting up a design machine run the following:
 ./setup.sh designer
 ```
 
-In addition to the Engineering applications, this script also installs the list of Design applications found in: [applications-designer.sh](https://github.com/pivotal/workstation-setup/blob/master/scripts/applications-designer.sh)
+In addition to the Engineering applications, this script also installs the list of Design applications found in: [applications-designer.sh](https://github.com/pivotal/workstation-setup/blob/master/scripts/opt-in/designer.sh)
 
 ## Having problems?
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you're setting up an engineering machine choose which languages to install:
 ./setup.sh developer c golang java docker
 ```
 
-The list of Engineering applications is found in: [applications-common.sh](https://github.com/pivotal/workstation-setup/blob/master/scripts/applications-common.sh)
+The list of Engineering applications is found in: [applications-common.sh](https://github.com/pivotal/workstation-setup/blob/master/scripts/common/applications-common.sh)
 
 ### Designer Machine
 


### PR DESCRIPTION
Noticed that clicking the links in the README for applications-common.sh or applications-designer.sh resulted in a 404. 