### PR TITLE
Add support for java 8. Move tools to separate script.

### DIFF
--- a/scripts/opt-in/java-tools.sh
+++ b/scripts/opt-in/java-tools.sh
@@ -1,0 +1,11 @@
+echo
+echo "Installing Java Development tools"
+brew cask install intellij-idea --force # guard against pre-installed intellij
+brew install maven
+brew install gradle
+brew install springboot
+
+source ${MY_DIR}/scripts/common/download-pivotal-ide-prefs.sh
+pushd ~/workspace/pivotal_ide_prefs/cli
+./bin/ide_prefs install --ide=intellij
+popd

--- a/scripts/opt-in/java.sh
+++ b/scripts/opt-in/java.sh
@@ -1,12 +1,4 @@
 echo
-echo "Installing Java Development tools"
+echo "Installing most recent version of Java"
 brew cask install java
-brew cask install intellij-idea --force # guard against pre-installed intellij
-brew install maven
-brew install gradle
-brew install springboot
-
-source ${MY_DIR}/scripts/common/download-pivotal-ide-prefs.sh
-pushd ~/workspace/pivotal_ide_prefs/cli
-./bin/ide_prefs install --ide=intellij
-popd
+source ${MY_DIR}/scripts/opt-in/java-tools.sh

--- a/scripts/opt-in/java8.sh
+++ b/scripts/opt-in/java8.sh
@@ -1,0 +1,4 @@
+echo
+echo "Installing Java 8"
+brew cask install java8
+source ${MY_DIR}/scripts/opt-in/java-tools.sh


### PR DESCRIPTION
This PR moves the java tool installation into a separate script, java-tools.sh. java.sh installs java 9 and then installs the tools. java8.sh installs java 8 and the installs the tools. 