### PR TITLE
Taps old casks in order to install java8

### DIFF
--- a/scripts/opt-in/java8.sh
+++ b/scripts/opt-in/java8.sh
@@ -1,4 +1,5 @@
 echo
 echo "Installing Java 8"
+brew tap caskroom/versions
 brew cask install java8
 source ${MY_DIR}/scripts/opt-in/java-tools.sh


### PR DESCRIPTION
The java8 script failed on my machine without having tapped old versions. (The current cask installs java 9)