### PR TITLE
Address warning: remove unnecessary flag, continue using new bosh cli

### DIFF
--- a/scripts/common/cloud-foundry.sh
+++ b/scripts/common/cloud-foundry.sh
@@ -2,5 +2,5 @@ echo
 echo "Installing Cloud Foundry Command-line Interface"
 brew tap cloudfoundry/tap
 brew install cf-cli
-brew install bosh-cli --without-bosh2
+brew install bosh-cli
 brew install bbl


### PR DESCRIPTION
See a similar PR to fix another warning message from `cloud-foundry.sh`: https://github.com/cloudfoundry/homebrew-tap/pull/45