### PR TITLE
Install and use neovim by default

### DIFF
--- a/scripts/common/applications-common.sh
+++ b/scripts/common/applications-common.sh
@@ -29,6 +29,7 @@ brew cask install skype
 
 # Text Editors
 
+brew install neovim
 brew cask install macdown
 brew cask install sublime-text
 brew cask install textmate

--- a/scripts/common/configurations.sh
+++ b/scripts/common/configurations.sh
@@ -17,4 +17,7 @@ if [ ! -d ~/.vim ]; then
 fi
 popd
 
+echo
+echo "Aliasing vim to neovim"
+alias vim=nvim
 

--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -15,5 +15,5 @@ cp files/.pairs ~/.pairs
 
 echo
 echo "Setting global Git configurations"
-git config --global core.editor /usr/bin/vim
+git config --global core.editor /usr/local/bin/nvim
 git config --global transfer.fsckobjects true

--- a/setup.sh
+++ b/setup.sh
@@ -21,13 +21,13 @@ brew cask install github
 brew cask install virtualbox
 brew cask install zoomus
 
-source ${MY_DIR}/scripts/common/git.sh
-source ${MY_DIR}/scripts/common/git-aliases.sh
-source ${MY_DIR}/scripts/common/cloud-foundry.sh
 source ${MY_DIR}/scripts/common/applications-common.sh
 source ${MY_DIR}/scripts/common/unix.sh
+source ${MY_DIR}/scripts/common/git.sh
+source ${MY_DIR}/scripts/common/git-aliases.sh
 source ${MY_DIR}/scripts/common/configuration-osx.sh
 source ${MY_DIR}/scripts/common/configurations.sh
+source ${MY_DIR}/scripts/common/cloud-foundry.sh
 
 # For each command line argument, try executing the corresponding script in opt-in/
 for var in "$@"


### PR DESCRIPTION
This cushions against the following error, caused by the `vim-go`
plugin, which is installed by the vim-config (separate repo):

```
> vim-go requires Vim 7.4.1689 or Neovim, but you're using an older version.
> Please update your Vim for the best vim-go experience.
> If you really want to continue you can set this to make the error go away:
>     let g:go_version_warning = 0
> Note that some features may error out or behave incorrectly.
> Please do not report bugs unless you're using Vim 7.4.1689 or newer.
```

Also, neovim is faster.

Necessary for this, I re-ordered some of the major modules in the main
`setup.sh` script so that if we fail halfway through, we don't have
configuration which refers to a binary (nvim) that isn't installed yet

Reopens and resolves #93

Note the `alias` -- is that how we want to be installing things like this? I'm used to it, but are there cases where it doesn't work well? At initial glance, neovim is doing well to pick up our existing configuration.