### PR TITLE
Add dep to golang install script

### DIFF
--- a/scripts/opt-in/golang.sh
+++ b/scripts/opt-in/golang.sh
@@ -3,6 +3,7 @@ echo "Installing Golang Development tools"
 
 mkdir -p ~/go/src
 brew install go
+brew install dep
 brew cask install goland
 
 source ${MY_DIR}/scripts/common/download-pivotal-ide-prefs.sh


### PR DESCRIPTION
Since dep (https://github.com/golang/dep) is the new standard Go dependency management tool and several teams in Data are starting to use it, we want to add it to the default setup.