### PR TITLE
git-author causes seattle-beach git-together install to fail

### DIFF
--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -4,8 +4,8 @@ brew install git
 brew tap git-duet/tap
 brew install git-duet
 brew install git-pair
-brew install git-author
 brew install seattle-beach/tap/git-together
+brew install git-author
 
 brew cask install rowanj-gitx
 brew cask install sourcetree


### PR DESCRIPTION
At commit d929075137b8d, git-author was added to setup scripts.

The `brew install git-together` from scripts/common/git.sh#L7 depends on
git-together [1].  This dependency installs git-together, and this
causes the command `brew install seattle-beach/tap/git-together` to fail
with the error:

==> Installing git-together from seattle-beach/tap
Error: git-together 0.1.0-alpha.11 is already installed
To upgrade to 0.1.0-alpha.13, run `brew upgrade git-together`

If we switch the order, the git-author dependancy on git-together can be
satisfied by the seattle-beach tap.

[1] https://github.com/pivotal/homebrew-tap/blob/master/git-author.rb#L7