### PR TITLE
Add a switch to bash_it so it does not prompt for confirmation

### DIFF
--- a/scripts/common/configuration-bash.sh
+++ b/scripts/common/configuration-bash.sh
@@ -10,7 +10,7 @@ rm -rf ~/.bash_it
 git clone https://github.com/Bash-it/bash-it.git ~/.bash_it
 cp files/add_user_initials_to_git_prompt_info.bash ~/.bash_it/custom
 cp files/bobby_pivotal/bobby_pivotal.theme.bash ~/.bash_it/themes/bobby/bobby.theme.bash
-~/.bash_it/install.sh
+~/.bash_it/install.sh --silent
 source ~/.bash_profile
 bash-it enable completion git
 bash-it enable plugin ssh


### PR DESCRIPTION

- this means users profile automatically gets moved to a backup file, which is
  what we want in the standard case of running these scripts on a clean machine