### PR TITLE
Add Google Analytics to track popular arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The tool will send anonymous user data to our Google Analytics account, so we ca
 # Remove unnecessary languages when running command
 SKIP_ANALYTICS=1 ./setup.sh java ruby node golang c docker
 ```
+This will also disable brew's [data collection](https://github.com/Homebrew/brew/blob/master/docs/Analytics.md).
 
 ## Having problems?
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ If you're setting up a machine for the XP workshop run the following:
 ./setup.sh java8 node
 ```
 
+## Analytics
+
+The tool will send anonymous user data to our Google Analytics account, so we can see what command line arguments are popular.  You can disable this:
+```
+# Remove unnecessary languages when running command
+SKIP_ANALYTICS=1 ./setup.sh java ruby node golang c docker
+```
+
 ## Having problems?
 
 If you're having problems using the setup script, please let us know by [opening an issue](https://github.com/pivotal/workstation-setup/issues/new).

--- a/files/ANALYTICS.md
+++ b/files/ANALYTICS.md
@@ -1,0 +1,16 @@
+Workstation-setup collects anonymous usage statistics to help us improve this tool.  An 'event' is logged with a Pivotal-owned Google Analytics account when `./setup` is started and when it is finished successfully.   
+
+This event contains the following data:
+- full list of command line options to `./setup`
+- the hostname of the machine you are running on (for deduplication)
+- a unique random number (to match start and finish events)
+
+Google analytics will also provide us with counts of approximate locations (nearest city) where workstation-setup was run.  We do NOT log your IP address or any other identifiable information, beyond the computer hostname.  
+
+Only Pivotal employees working on workstation-setup will be able to see the analytics results.  
+
+You can disable all analytics by using an environment variable:
+```
+SKIP_ANALYTICS=1 ./setup.sh java ruby node golang c docker
+```
+This will also disable brew's [data collection](https://github.com/Homebrew/brew/blob/master/docs/Analytics.md).  

--- a/scripts/helpers/google-analytics.sh
+++ b/scripts/helpers/google-analytics.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo "Sending google analytics for $2"
+
+clientID=$1
+shift
+argsunderscore="$*"
+argsunderscore=${argsunderscore// /_}
+
+curl -X POST \
+  --silent -o /dev/null \
+  --data "v=1&t=event&tid=UA-117461559-1&uid=$(hostname)&cid=${clientID}&ec=setup&ea=${argsunderscore}"  \
+  https://www.google-analytics.com/collect 
+
+  

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,8 @@ sudo -K
 sudo true;
 
 MY_DIR="$(dirname "$0")"
-
+clientID=$(od -vAn -N4 -tx  < /dev/urandom)
+source ${MY_DIR}/scripts/helpers/google-analytics.sh ${clientID} start $@
 clear
 
 # Note: Homebrew needs to be set up first
@@ -43,3 +44,4 @@ do
 done
 
 source ${MY_DIR}/scripts/common/finished.sh
+source ${MY_DIR}/scripts/helpers/google-analytics.sh ${clientID} finish $@

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+#
+# setup.sh:  run the Pivotal workstation setup
+#
+# Arguments:
+#   - a list of components to install, see scripts/opt-in/ for valid options
+#
+# Environment variables:
+#   - SKIP_ANALYTICS:  Set this to 1 to not send usuage data to our Google Analytics account 
+#
 
 # Fail immediately if any errors occur
 set -e
@@ -6,11 +15,14 @@ set -e
 echo "Caching password..."
 sudo -K
 sudo true;
+clear
 
 MY_DIR="$(dirname "$0")"
-clientID=$(od -vAn -N4 -tx  < /dev/urandom)
-source ${MY_DIR}/scripts/helpers/google-analytics.sh ${clientID} start $@
-clear
+SKIP_ANALYTICS=${SKIP_ANALYTICS:-0}
+if (( SKIP_ANALYTICS == 0 )); then
+    clientID=$(od -vAn -N4 -tx  < /dev/urandom)
+    source ${MY_DIR}/scripts/helpers/google-analytics.sh ${clientID} start $@
+fi
 
 # Note: Homebrew needs to be set up first
 source ${MY_DIR}/scripts/common/homebrew.sh
@@ -44,4 +56,6 @@ do
 done
 
 source ${MY_DIR}/scripts/common/finished.sh
-source ${MY_DIR}/scripts/helpers/google-analytics.sh ${clientID} finish $@
+if (( SKIP_ANALYTICS == 0 )); then
+    source ${MY_DIR}/scripts/helpers/google-analytics.sh ${clientID} finish $@
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,8 @@ SKIP_ANALYTICS=${SKIP_ANALYTICS:-0}
 if (( SKIP_ANALYTICS == 0 )); then
     clientID=$(od -vAn -N4 -tx  < /dev/urandom)
     source ${MY_DIR}/scripts/helpers/google-analytics.sh ${clientID} start $@
+else
+    export HOMEBREW_NO_ANALYTICS=1
 fi
 
 # Note: Homebrew needs to be set up first


### PR DESCRIPTION
AS a workstation contributor
I WANT to measure usage frequency and patterns
SO THAT I can direct my development efforts most effectively

Our discussion of virtualbox made me wonder who is using this script and what command lines options they are using.  

To measure this, I added two simple curl calls to the setup.sh (using a new helper script).  These two calls will log starting the workstation-setup and finishing the setup by creating an event in Google Analytics.  Obviously, we can compute success rate from this. 

Example output:
```
| 1. | finish_ruby_go_java | 6(50.00%)
| 2. | start_ruby_go_java  | 6(50.00%)
```

The analytics dashboard that I used is under my pivotal account, so I can share with others.  Screenshot of what it looks like: https://docs.google.com/document/d/15B0AhcG1t_jn_U7KyuKYxZg_am6l-Dv7kkfKr1s4QQ0/edit?usp=sharing  (pivots only)

I briefly looked into "time to complete workstation setup", but that is a next story as Google Analytics does not keep track of time itself.

What do you think?
