### PR TITLE
Make setting up git-hooks-core idempotent

### DIFF
--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -19,11 +19,21 @@ echo "Setting global Git configurations"
 git config --global core.editor /usr/bin/vim
 git config --global transfer.fsckobjects true
 
-echo
-echo "Installing git hooks for cred-alert"
-# for more information see https://github.com/pivotal-cf/git-hooks-core
-git clone https://github.com/pivotal-cf/git-hooks-core $HOME/workspace/git-hooks-core
-git config --global --add core.hooksPath $HOME/workspace/git-hooks-core
+HOOKS_DIRECTORY=$HOME/workspace/git-hooks-core
+if [ ! -d $HOOKS_DIRECTORY ]; then
+  echo
+  echo "Installing git hooks for cred-alert"
+  # for more information see https://github.com/pivotal-cf/git-hooks-core
+  git clone https://github.com/pivotal-cf/git-hooks-core $HOOKS_DIRECTORY
+  git config --global --add core.hooksPath $HOOKS_DIRECTORY
+else
+  echo
+  echo "Updating git-hooks for cred-alert"
+  pushd $HOOKS_DIRECTORY
+  git pull -r
+  popd
+fi
+
 # install cred-alert-cli
 os_name=$(uname | awk '{print tolower($1)}')
 curl -o cred-alert-cli \


### PR DESCRIPTION
Running the setup multiple times was failing on High Sierra. First run was fine, subsequent runs are failing due to `$HOME/workspace/git-hooks-core` being present already. Also, we were littering the git config with multiple `core.hookspath` values pointing to that directory.

Changed the script `scripts/common/git.sh`so that it :
- only clones the pivotal-cf/git-hooks-core repo on the first run
- only adds the git config core.hookspath on the first run
- on subsequent runs, pulls the latest changes

Note: one assumption we made is that you will not be changing the git-hooks-core repo locally ; this is why we allow a git pull -r on it.