### PR TITLE
Fix alignment of git duet initials

### DIFF
--- a/files/add_user_initials_to_git_prompt_info.bash
+++ b/files/add_user_initials_to_git_prompt_info.bash
@@ -1,7 +1,7 @@
 function git_prompt_info {
   git_prompt_vars
   GIT_TOGETHER=$(git config git-together.active)
-  GIT_DUET_INITIALS=$(git config --get-regexp ^duet.env.git-.*-name | sed -e 's/^.*-name //' | tr 'A-Z' 'a-z' | sed -e 's/\([a-z]\)[^ +]*./\1/g' | sed -e 's/ /+/')
+  GIT_DUET_INITIALS=$(echo $(git config --get-regexp ^duet.env.git-.*-name | sed -e 's/^.*-name //' | tr 'A-Z' 'a-z' | sed -e 's/\([a-z]\)[^ +]*./\1/g') | sed -e 's/ /+/')
   GIT_PAIR=${GIT_DUET_INITIALS:-`git config user.initials | sed 's% %+%'`}
   GIT_INITIALS=${GIT_TOGETHER:-$GIT_PAIR}
   echo -e " $GIT_INITIALS$SCM_PREFIX$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"


### PR DESCRIPTION
On my last two projects I've observed that the visualization of the git duet initials will be broken on OSX machines that have run this setup project. Instead of showing the pair initials in one line (such as dn + to) it instead puts a newline after the + sign.

I know it didn't used to do this, and it looks like there was a change that broke it with this commit:
https://github.com/Pivotal/workstation-setup/commit/d8e4bfa99848f8e219d21aa85439ebcbc580a376#diff-ce247062a551e6172d6370799952a8c7

I'm not super great with bash, but reinserting the echo that wraps the git config command appears to resolve the issue.