### PR TITLE
Homebrew installation no longer pauses

### DIFF
--- a/scripts/common/homebrew.sh
+++ b/scripts/common/homebrew.sh
@@ -4,7 +4,7 @@ if hash brew 2>/dev/null; then
   echo "Homebrew is already installed!"
 else
   echo "Installing Homebrew..."
-  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  yes '' | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
 echo


### PR DESCRIPTION
This pipes a newline into the homebrew installation script to prevent
a pause in the process.

Signed-off-by: Matthew Conger-Eldeen <mcongereldeen@pivotal.io>