### PR TITLE
Use latest vim

### DIFF
--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -6,6 +6,8 @@ brew install git-duet
 brew install git-pair
 brew install git-together
 brew install git-author
+# Get latest version of vim
+brew install vim --with-override-system-vi
 
 brew cask install rowanj-gitx
 brew cask install sourcetree
@@ -16,7 +18,7 @@ cp files/.pairs ~/.pairs
 
 echo
 echo "Setting global Git configurations"
-git config --global core.editor /usr/bin/vim
+git config --global core.editor /usr/local/bin/vim
 git config --global transfer.fsckobjects true
 
 HOOKS_DIRECTORY=$HOME/workspace/git-hooks-core

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@
 #   - a list of components to install, see scripts/opt-in/ for valid options
 #
 # Environment variables:
-#   - SKIP_ANALYTICS:  Set this to 1 to not send usuage data to our Google Analytics account 
+#   - SKIP_ANALYTICS:  Set this to 1 to not send usage data to our Google Analytics account
 #
 
 # Fail immediately if any errors occur


### PR DESCRIPTION
The default mac os installation of vim is old so the vim-go plugin installed by workstation-setup produces the following error every time you start vim:

`vim-go requires Vim 7.4.2009 or Neovim, but you're using an older version.`

Hopefully this should fix that.