### PR TITLE
Update ide_prefs to use Goland's new name

### DIFF
--- a/scripts/opt-in/golang.sh
+++ b/scripts/opt-in/golang.sh
@@ -8,5 +8,5 @@ brew cask install goland
 
 source ${MY_DIR}/scripts/common/download-pivotal-ide-prefs.sh
 pushd ~/workspace/pivotal_ide_prefs/cli
-./bin/ide_prefs install --ide=gogland
+./bin/ide_prefs install --ide=goland
 popd


### PR DESCRIPTION
When I was settings my workstation the script failed and I had to modify the `--ide` property to be able to install goland on my workstation. Hopefully this can help others.