### PR TITLE
Homebrew dir: use -f flag when chown'ing /usr/local/bin

### DIFF
--- a/scripts/common/homebrew.sh
+++ b/scripts/common/homebrew.sh
@@ -13,7 +13,7 @@ brew update
 
 echo
 echo "Ensuring your Homebrew directory is writable..."
-sudo chown -R $(whoami) /usr/local/bin
+sudo chown -Rf $(whoami) $(brew --prefix)/*
 
 echo
 echo "Installing Homebrew services..."


### PR DESCRIPTION
- sentinelone isn't chownable, and this flags silently skips this failure.
- Fixes #240, as per @textbook suggestion.