### PR TITLE
Add hooks to source scripts before and after setup

### DIFF
--- a/scripts/common/git-aliases.sh
+++ b/scripts/common/git-aliases.sh
@@ -1,6 +1,6 @@
 echo
 echo "Setting up Git aliases..."
-git config --global alias.gst git status
+git config --global alias.gst "git status"
 git config --global alias.st status
 git config --global alias.di diff
 git config --global alias.co checkout

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,13 @@ sudo -K
 sudo true;
 clear
 
+pre_setup_dir="$HOME/.pivotal-workstation-pre-setup"
+if [ -d "$pre_setup_dir" ]; then
+    for file in $(ls "$pre_setup_dir"); do
+        source "$pre_setup_dir/$file"
+    done
+fi
+
 MY_DIR="$(dirname "$0")"
 SKIP_ANALYTICS=${SKIP_ANALYTICS:-0}
 if (( SKIP_ANALYTICS == 0 )); then
@@ -55,6 +62,13 @@ do
        echo "Warning: $var does not appear to be a valid argument. File $FILE does not exist."
     fi
 done
+
+post_setup_dir="$HOME/.pivotal-workstation-post-setup"
+if [ -d "$post_setup_dir" ]; then
+    for file in $(ls "$post_setup_dir"); do
+        source "$post_setup_dir/$file"
+    done
+fi
 
 source ${MY_DIR}/scripts/common/finished.sh
 if (( SKIP_ANALYTICS == 0 )); then


### PR DESCRIPTION
We would like to use this repo without forking it, so this PR adds hooks so that we can execute scripts before and after running the setup. If `$HOME/.pivotal-workstation-pre-setup` and/or `$HOME/.pivotal-workstation-post-setup`, scripts in them will be executed before and after the bulk of `setup.sh`.

Also, fixes git status alias.