### PR TITLE
Update cask versions tap

### DIFF
--- a/scripts/opt-in/java8.sh
+++ b/scripts/opt-in/java8.sh
@@ -1,5 +1,5 @@
 echo
 echo "Installing Java 8"
-brew tap caskroom/versions
+brew tap homebrew/cask-versions
 brew cask install java8
 source ${MY_DIR}/scripts/opt-in/java-tools.sh


### PR DESCRIPTION
`caskroom/versions` deprecated in 2018 (Caskroom/caskroom.github.io#68) in favor of `homebrew/cask-versions`.