### PR TITLE
Add git alias for commit --amend --no-edit

### DIFF
--- a/scripts/common/git-aliases.sh
+++ b/scripts/common/git-aliases.sh
@@ -17,6 +17,7 @@ git config --global alias.blog "log origin/master... --left-right"
 git config --global alias.ds "diff --staged"
 git config --global alias.fixup "commit --fixup"
 git config --global alias.squash "commit --squash"
+git config --global alias.amendit "commit --amend --no-edit"
 git config --global alias.unstage "reset HEAD"
 git config --global alias.rum "rebase master@{u}"
 mkdir ~/.bash_it/aliases/enabled


### PR DESCRIPTION
This is a common command that I use all the time on projects, such that I have started adding this alias manually each time I set up a machine