### PR TITLE
Add opt-in script for iOS tools

### DIFF
--- a/scripts/opt-in/ios.sh
+++ b/scripts/opt-in/ios.sh
@@ -1,0 +1,12 @@
+echo
+echo "Installing iOS developer tools"
+
+# package managers
+sudo gem install cocoapods
+brew install carthage
+
+# deployment manager
+brew install fastlane
+
+# ide
+brew cask install appcode --force


### PR DESCRIPTION
Includes
- package managers: `carthage`, `cocoapods`
- deployment tools: `fastlane`
- ide: `appcode`
