### PR TITLE
Add kubernetes.sh opt-in for local k8s setup

### DIFF
--- a/scripts/opt-in/kubernetes.sh
+++ b/scripts/opt-in/kubernetes.sh
@@ -1,0 +1,7 @@
+# Kubernetes
+brew install kind
+brew install kubectl
+brew link --overwrite kubernetes-cli
+brew install kustomize
+brew install helm
+brew install skaffold


### PR DESCRIPTION
This PR adds a new opt-in script: `Kubernetes.sh`, which installs the following tools useful for developing a Kubernetes application.

- kind
- kubectl
- kustomize
- helm
- skaffold
