### PR TITLE
Remove ruby version from prompt

### DIFF
--- a/files/bobby_pivotal/bobby_pivotal.theme.bash
+++ b/files/bobby_pivotal/bobby_pivotal.theme.bash
@@ -15,7 +15,7 @@ RVM_THEME_PROMPT_SUFFIX="|"
 # This Pivotal's customization of the bobby theme
 
 function prompt_command() {
-    PS1="\n$(battery_char) ${yellow}$(ruby_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
+    PS1="\n$(battery_char) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
 }
 
 PROMPT_COMMAND=prompt_command;


### PR DESCRIPTION
No need to have the ruby version on my face all the time