### PR TITLE
file checks

### DIFF
--- a/scripts/common/configuration-osx.sh
+++ b/scripts/common/configuration-osx.sh
@@ -23,11 +23,13 @@ defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true
 
 
 # modify appearance of dock: remove standard icons, add chrome and iTerm
-curl https://raw.githubusercontent.com/kcrawford/dockutil/master/scripts/dockutil > /usr/local/bin/dockutil
+if [ ! -e /usr/local/bin/dockutil ]; then
+    curl https://raw.githubusercontent.com/kcrawford/dockutil/master/scripts/dockutil > /usr/local/bin/dockutil
+fi
 chmod a+rx,go-w /usr/local/bin/dockutil
 dockutil --list | awk -F\t '{print "dockutil --remove \""$1"\" --no-restart"}' | sh
 dockutil --add /Applications/Google\ Chrome.app --no-restart
 dockutil --add /Applications/iTerm.app
 
- 
- 
+
+

--- a/scripts/common/git-aliases.sh
+++ b/scripts/common/git-aliases.sh
@@ -20,7 +20,9 @@ git config --global alias.squash "commit --squash"
 git config --global alias.amendit "commit --amend --no-edit"
 git config --global alias.unstage "reset HEAD"
 git config --global alias.rum "rebase master@{u}"
-mkdir ~/.bash_it/aliases/enabled
+if [ ! -d ~/.bash_it/aliases/enabled ]; then
+    mkdir ~/.bash_it/aliases/enabled
+fi
 echo "#Git" >> ~/.bash_it/aliases/enabled/general.aliases.bash
 echo "alias gst='git status'" >> ~/.bash_it/aliases/enabled/general.aliases.bash
 


### PR DESCRIPTION
check for existence before creating `dockutil` and making the `bash_it/aliases/enabled` directory

instead of naive creation (errors out)