### PR TITLE
Homebrew Deprecations and Reduce the Number of Setup Commands 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ This project does not aim to do everything. Some examples:
 - If you are not on High Sierra, you need to install the latest version of [Xcode](https://developer.apple.com/xcode/)
 - On High Sierra, once you have used git (below), you will have installed the command line developer tools
 
-Open up Terminal.app and run the following commands:
+Open up Terminal.app and run the following command:
 
 ```sh
-mkdir -p ~/workspace
-cd ~/workspace
-git clone https://github.com/pivotal/workstation-setup.git
-cd workstation-setup
+mkdir -p ~/workspace &&
+  cd ~/workspace &&
+  git clone https://github.com/pivotal/workstation-setup.git &&
+  cd workstation-setup
 ```
 
 ### Engineering Machine

--- a/scripts/common/applications-common.sh
+++ b/scripts/common/applications-common.sh
@@ -7,36 +7,36 @@ echo "Installing applications"
 
 # Utilities
 
-brew cask install flycut
-brew cask install shiftit
+brew install --cask flycut
+brew install --cask shiftit
 echo
 echo "configure shiftit to select 1/3 screen width, 1/2 screen width and 2/3 screen width:"
 echo "`defaults write org.shiftitapp.ShiftIt multipleActionsCycleWindowSizes YES`"
 echo
-brew cask install dash
-brew cask install postman
-brew cask install quicklook-json
+brew install --cask dash
+brew install --cask postman
+brew install --cask quicklook-json
 
 # Terminals
 
-brew cask install iterm2
+brew install --cask iterm2
 
 # Browsers
 
-brew cask install google-chrome
-brew cask install firefox
+brew install --cask google-chrome
+brew install --cask firefox
 
 # Communication
 
-brew cask install slack
+brew install --cask slack
 
 # Text Editors
 
-brew cask install macdown
-brew cask install sublime-text
-brew cask install textmate
-brew cask install macvim
-brew cask install jetbrains-toolbox --force # guard against pre-installed jetbrains-toolbox
-brew cask install visual-studio-code
-brew cask install atom
+brew install --cask macdown
+brew install --cask sublime-text
+brew install --cask textmate
+brew install --cask macvim
+brew install --cask jetbrains-toolbox --force # guard against pre-installed jetbrains-toolbox
+brew install --cask visual-studio-code
+brew install --cask atom
 set -e

--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -8,9 +8,9 @@ brew install git-together
 brew install git-author
 brew install vim
 
-brew cask install rowanj-gitx
-brew cask install sourcetree
-brew cask install gitup
+brew install --cask rowanj-gitx
+brew install --cask sourcetree
+brew install --cask gitup
 
 echo
 echo "Putting a sample git-pair file in ~/.pairs"

--- a/scripts/common/homebrew.sh
+++ b/scripts/common/homebrew.sh
@@ -4,7 +4,7 @@ if hash brew 2>/dev/null; then
   echo "Homebrew is already installed!"
 else
   echo "Installing Homebrew..."
-  yes '' | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  yes '' | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
 echo

--- a/scripts/opt-in/c.sh
+++ b/scripts/opt-in/c.sh
@@ -4,7 +4,7 @@ brew install ccache
 brew install ctags
 brew install cmake
 brew install cscope
-brew cask install clion
+brew install --cask clion
 brew install ninja
 
 source ${MY_DIR}/scripts/common/download-pivotal-ide-prefs.sh

--- a/scripts/opt-in/designer.sh
+++ b/scripts/opt-in/designer.sh
@@ -9,14 +9,14 @@ echo "Installing Designer applications"
 
 # Graphic editing tools
 
-brew cask install adobe-creative-cloud
-brew cask install sketch
+brew install --cask adobe-creative-cloud
+brew install --cask sketch
 
 # Screen recording tools
 
-brew cask install recordit
-brew cask install skitch
-brew cask install licecap
-brew cask install screenflow
+brew install --cask recordit
+brew install --cask skitch
+brew install --cask licecap
+brew install --cask screenflow
 
 set -e

--- a/scripts/opt-in/docker.sh
+++ b/scripts/opt-in/docker.sh
@@ -2,7 +2,7 @@
 set +e
 
 # Docker
-brew cask install docker
+brew install --cask docker
 echo "To get docker command-line tools, run the docker application"
 
 # Docker Bash Completion

--- a/scripts/opt-in/dotnet-tools.sh
+++ b/scripts/opt-in/dotnet-tools.sh
@@ -1,3 +1,3 @@
 echo
 echo "Installing dotnet development tools"
-brew cask install visual-studio
+brew install --cask visual-studio

--- a/scripts/opt-in/dotnet.sh
+++ b/scripts/opt-in/dotnet.sh
@@ -1,4 +1,4 @@
 echo
 echo "Installing dotnet requirements"
-brew cask install dotnet dotnet-sdk
+brew install --cask dotnet dotnet-sdk
 source ${MY_DIR}/scripts/opt-in/dotnet-tools.sh

--- a/scripts/opt-in/golang.sh
+++ b/scripts/opt-in/golang.sh
@@ -4,7 +4,7 @@ echo "Installing Golang Development tools"
 mkdir -p ~/go/src
 brew install go
 brew install dep
-brew cask install goland
+brew install --cask goland
 
 source ${MY_DIR}/scripts/common/download-pivotal-ide-prefs.sh
 pushd ~/workspace/pivotal_ide_prefs/cli

--- a/scripts/opt-in/ios.sh
+++ b/scripts/opt-in/ios.sh
@@ -9,4 +9,4 @@ brew install carthage
 brew install fastlane
 
 # ide
-brew cask install appcode --force
+brew install --cask appcode --force

--- a/scripts/opt-in/java-tools.sh
+++ b/scripts/opt-in/java-tools.sh
@@ -1,6 +1,6 @@
 echo
 echo "Installing Java Development tools"
-brew cask install intellij-idea --force # guard against pre-installed intellij
+brew install --cask intellij-idea --force # guard against pre-installed intellij
 brew tap jcgay/jcgay
 brew install maven-deluxe
 brew install gradle

--- a/scripts/opt-in/java.sh
+++ b/scripts/opt-in/java.sh
@@ -1,4 +1,4 @@
 echo
 echo "Installing most recent version of Java"
-brew cask install java
+brew install --cask java
 source ${MY_DIR}/scripts/opt-in/java-tools.sh

--- a/scripts/opt-in/python.sh
+++ b/scripts/opt-in/python.sh
@@ -2,7 +2,7 @@ echo
 echo "Installing Python tools"
 
 # guard against pre-installed pycharm
-brew cask install pycharm --force
+brew install --cask pycharm --force
 
 source ${MY_DIR}/scripts/common/download-pivotal-ide-prefs.sh
 pushd ~/workspace/pivotal_ide_prefs/cli

--- a/scripts/opt-in/ruby.sh
+++ b/scripts/opt-in/ruby.sh
@@ -9,7 +9,7 @@ gem install bundler
 rbenv rehash
 
 # guard against pre-installed rubymine
-brew cask install rubymine --force
+brew install --cask rubymine --force
 
 source ${MY_DIR}/scripts/common/download-pivotal-ide-prefs.sh
 pushd ~/workspace/pivotal_ide_prefs/cli

--- a/setup.sh
+++ b/setup.sh
@@ -31,8 +31,8 @@ source ${MY_DIR}/scripts/common/homebrew.sh
 source ${MY_DIR}/scripts/common/configuration-bash.sh
 
 # Place any applications that require the user to type in their password here
-brew cask install github
-brew cask install zoomus
+brew install --cask github
+brew install --cask zoomus
 
 source ${MY_DIR}/scripts/common/git.sh
 source ${MY_DIR}/scripts/common/git-aliases.sh


### PR DESCRIPTION
Summary of Changes:
1. [Update homebrew installer link](https://brew.sh/) (ruby one is now deprecated)
2. Update homebrew cask syntax ([example](https://formulae.brew.sh/cask/github#default))
3. Reduce the number of commands the user needs to run when setting up from 4 to 1 by &-ing the commands. The -p ensures that any existing workspace directory is not overwritten, so it shouldn't matter if the user runs `mkdir workspace` when they already have that directory. 

Verified these changes by running the workstation setup on a 10.15 mac. 
- No homebrew related errors or warnings
- Casks installed correctly (spot checked Slack and Zoom)
