### PR TITLE
Remove reference to git-together

### DIFF
--- a/scripts/common/finished.sh
+++ b/scripts/common/finished.sh
@@ -12,13 +12,6 @@ echo "sudo scutil --set HostName newname"
 echo
 echo "For pair programming, git-duet is installed. https://github.com/git-duet/git-duet"
 echo "To configure your pairs, edit ~/.git-authors"
-echo ""
-echo "To enable git together:"
-echo "echo 'alias git=git-together' >> ~/.bash_profile"
-echo "and then follow the configuration instructions at https://github.com/kejadlen/git-together"
-echo ""
-echo "To use git-author:"
-echo "echo 'export GIT_TOGETHER_NO_SIGNOFF=1' >> ~/.bash_profile"
 
 echo
 echo "After checking the above output for any problems, start a new iTerm session to make use of all the installed tools."


### PR DESCRIPTION
I noticed that `git-together` was still referenced in `finished.sh` so I removed the reference.

It's still referenced in `add_user_initials_to_git_prompt_info.bash`, but I left that in there just in case people install a different tool and want this to be visible in their git prompt, though I'm happy to remove it from there too in this PR if we'd like to.