### PR TITLE
Get actual vim location for git editor

### DIFF
--- a/scripts/common/configuration-osx.sh
+++ b/scripts/common/configuration-osx.sh
@@ -23,10 +23,7 @@ defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true
 
 
 # modify appearance of dock: remove standard icons, add chrome and iTerm
-if [ ! -e /usr/local/bin/dockutil ]; then
-    curl https://raw.githubusercontent.com/kcrawford/dockutil/master/scripts/dockutil > /usr/local/bin/dockutil
-fi
-chmod a+rx,go-w /usr/local/bin/dockutil
+brew install dockutil
 dockutil --list | awk -F\t '{print "dockutil --remove \""$1"\" --no-restart"}' | sh
 dockutil --add /Applications/Google\ Chrome.app --no-restart
 dockutil --add /Applications/iTerm.app

--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -4,7 +4,7 @@ brew install git
 
 echo
 echo "Setting global Git configurations"
-git config --global core.editor /usr/local/bin/vim
+git config --global core.editor "$(brew --prefix)/bin/vim"
 git config --global transfer.fsckobjects true
 
 mkdir -p ~/.git_templates

--- a/scripts/opt-in/cred-alert.sh
+++ b/scripts/opt-in/cred-alert.sh
@@ -20,4 +20,4 @@ os_name=$(uname | awk '{print tolower($1)}')
 curl -L -o cred-alert-cli \
   https://github.com/pivotal-cf/cred-alert/releases/latest/download/cred-alert-cli_${os_name}
 chmod 755 cred-alert-cli
-mv cred-alert-cli /usr/local/bin # <= or other directory in ${PATH}
+mv cred-alert-cli "$(brew --prefix)/bin" # <= or other directory in ${PATH}

--- a/scripts/opt-in/docker.sh
+++ b/scripts/opt-in/docker.sh
@@ -8,7 +8,7 @@ echo "To get docker command-line tools, run the docker application"
 # Docker Zsh Completion
 # Reference https://docs.docker.com/docker-for-mac/
 etc=/Applications/Docker.app/Contents/Resources/etc
-ln -s $etc/docker.zsh-completion /usr/local/share/zsh/site-functions/_docker
-ln -s $etc/docker-compose.zsh-completion /usr/local/share/zsh/site-functions/_docker-composepopd
+ln -s $etc/docker.zsh-completion "$(brew --prefix)/share/zsh/site-functions/_docker"
+ln -s $etc/docker-compose.zsh-completion "$(brew --prefix)/share/zsh/site-functions/_docker-composepopd"
 
 set -e

--- a/scripts/opt-in/java.sh
+++ b/scripts/opt-in/java.sh
@@ -3,9 +3,9 @@ echo "Installing most recent version of OpenJDK"
 brew install openjdk
 
 # Configure opensjdk as instructed by 'brew info openjdk'
-sudo ln -sfn /usr/local/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
-echo 'export PATH="/usr/local/opt/openjdk/bin:$PATH"' >> ~/.zshenv
-echo 'export CPPFLAGS="-I/usr/local/opt/openjdk/include"' >> ~/.zshenv
+sudo ln -sfn "$(brew --prefix)/opt/openjdk/libexec/openjdk.jdk" /Library/Java/JavaVirtualMachines/openjdk.jdk
+echo "export PATH=\"$(brew --prefix)/opt/openjdk/bin:\$PATH\"" >> ~/.zshenv
+echo "export CPPFLAGS=\"-I$(brew --prefix)/opt/openjdk/include\"" >> ~/.zshenv
 
 # more java tools
 source ${MY_DIR}/scripts/opt-in/java-tools.sh


### PR DESCRIPTION
Homebrew on M1 machines installs to `/opt/homebrew`, not `/usr/local` (see Homebrew/brew#9177). So I ended up seeing:

```
hint: Waiting for your editor to close the file... fatal: cannot run /usr/local/bin/vim: No such file or directory
error: unable to start editor '/usr/local/bin/vim'
Please supply the message using either -m or -F option.
```

This uses the `brew --prefix` to look in the right place in either architecture.