### PR TITLE
Switch to using thirdparty cask for dockutil

### DIFF
--- a/scripts/common/configuration-osx.sh
+++ b/scripts/common/configuration-osx.sh
@@ -22,7 +22,7 @@ defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true
 #to revert use defaults -currentHost delete com.apple.ImageCapture disableHotPlug
 
 # modify appearance of dock: remove standard icons, add chrome and iTerm
-if [ ! -e /usr/local/bin/dockutil ]; then
+if ! dockutil ; then
   # dockutil is not installed
   brew install --cask hpedrorodrigues/tools/dockutil
 fi

--- a/scripts/common/configuration-osx.sh
+++ b/scripts/common/configuration-osx.sh
@@ -24,7 +24,7 @@ defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true
 # modify appearance of dock: remove standard icons, add chrome and iTerm
 if [ ! -e /usr/local/bin/dockutil ]; then
   # dockutil is not installed
-  brew install dockutil
+  brew install --cask hpedrorodrigues/tools/dockutil
 fi
 dockutil --list | awk -F\t '{print "dockutil --remove \""$1"\" --no-restart"}' | sh
 dockutil --add /Applications/Google\ Chrome.app --no-restart


### PR DESCRIPTION
- This is intended as a temporary change
- Waiting on PR: https://github.com/Homebrew/homebrew-core/pull/97394 to
  update dockutil to version 3.0.2

Fixes #316 

Authored-by: Sam Mirza <mirzasa@vmware.com>