### PR TITLE
Adding flag to allow you to list out the opt-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,20 @@ mkdir -p ~/workspace &&
 ## Using this tool
 Within `~/workspace/workstation-setup`, run the following:
 
-```shell
-./setup.sh [list of optional configurations]
+```sh
+./setup.sh [--list] [list of optional configurations]
 ```
 
 Examples:
-```shell
+```sh
 # This will only install the default items
 ./setup.sh 
 
 # This will install the latest Java and Docker
 ./setup.sh java docker
+
+# This will only print a list of optional configurations available
+./setup.sh --list
 ```
 
 **Warning: this tool might overwrite existing configurations.**
@@ -63,7 +66,7 @@ We recommend that you look at `setup.sh` to see what is automatically installed.
 ### Opt-In Configurations
 Please look in `scripts/opt-in/` for optional, opt-in configurations. Some of these are languages and associated frameworks, such as `java` and `golang`. Some are supporting infrastructure, such as `docker` and `kubernetes`. Others might be specific tools for application platforms, such as `cloud-foundry`.
 
-To install any of these, add them as arguments to `$> setup.sh`. Examples: 
+To install any of these, add them as arguments to `setup.sh`. Examples: 
 
 ```sh
 # Common for Spring Boot development
@@ -74,6 +77,12 @@ To install any of these, add them as arguments to `$> setup.sh`. Examples:
 
 # Love those platforms!
 ./setup.sh golang docker kubernetes cloud-foundry terraform concourse
+```
+
+To see a list of available optional, opt-in configurations, run the following:
+
+```sh
+./setup.sh --list
 ```
 
 ## Analytics

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@
 #
 # Arguments:
 #   - a list of components to install, see scripts/opt-in/ for valid options
+#   - --list to print out the available opt-ins
 #
 # Environment variables:
 #   - SKIP_ANALYTICS:  Set this to 1 to not send usage data to our Google Analytics account
@@ -12,12 +13,42 @@
 # Fail immediately if any errors occur
 set -e
 
+MY_DIR="$(dirname "$0")"
+OPT_IN_FOLDER="${MY_DIR}/scripts/opt-in"
+
+function has_param() {
+    local flags="$1"
+    shift 1 # pull the flags you're looking for out of the args list
+    for flag in $flags; do
+        for arg in $@; do
+            if [[ $arg == "$flag" ]]; then
+                return 0;
+            fi
+        done
+    done
+    return 1
+}
+
+function present_opt_ins() {
+    shopt -s nullglob
+    local optIns=($OPT_IN_FOLDER/*)
+    shopt -u nullglob # Turn off nullglob to make sure it doesn't interfere with anything later
+
+    for option in ${optIns[@]}; do
+      echo $option | sed -e "s:\.sh$::" -e "s:${OPT_IN_FOLDER}/::"
+    done
+}
+
+if has_param "--list" "$@"; then
+    present_opt_ins
+    exit
+fi
+
 echo "Caching password..."
 sudo -K
 sudo true;
 clear
 
-MY_DIR="$(dirname "$0")"
 SKIP_ANALYTICS=${SKIP_ANALYTICS:-0}
 if (( SKIP_ANALYTICS == 0 )); then
     clientID=$(od -vAn -N4 -tx  < /dev/urandom)


### PR DESCRIPTION
Based on feedback from #300 this is PR simply adds the ability to list out available opt-ins using the `--list` flag to `setup.sh`. I had it check for the flag before the script runs `sudo -K` because listing out the options would not require admin and wouldn't actually be installing anything. If it is preferred that it runs after the analytics are turned on / off then I can rearrange some of the code to allow for that.

In my view, the only potential `more-complicated-than-it-perhaps-needs-to-be` part is the `has_param` method, which I have to allow for alternate flags (long and compact forms if desired in future), because I was tossing around the idea of allowing a compact flag like `-l` as an alternative to `--list`.