### PR TITLE
Return to using the official Dockutil formula

### DIFF
--- a/scripts/common/configuration-osx.sh
+++ b/scripts/common/configuration-osx.sh
@@ -24,7 +24,7 @@ defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true
 # modify appearance of dock: remove standard icons, add chrome and iTerm
 if ! dockutil ; then
   # dockutil is not installed
-  brew install --cask hpedrorodrigues/tools/dockutil
+  brew install dockutil
 fi
 dockutil --list | awk -F\t '{print "dockutil --remove \""$1"\" --no-restart"}' | sh
 dockutil --add /Applications/Google\ Chrome.app --no-restart


### PR DESCRIPTION
- Temporary fix dec2fe3 is no longer needed, official formula is up-to-date (currently v3.1.3)
- [`hpedrorodrigues/homebrew-tools`](https://github.com/hpedrorodrigues/homebrew-tools) has deprecated Dockutil in favour of the official formula