### PR TITLE
Add https://mob.sh remote handover tool to common git config

### DIFF
--- a/scripts/common/finished.sh
+++ b/scripts/common/finished.sh
@@ -12,6 +12,8 @@ echo "sudo scutil --set HostName newname"
 echo
 echo "For pair programming, git-duet is installed. https://github.com/git-duet/git-duet"
 echo "To configure your pairs, edit ~/.git-authors"
+echo "For remote pairing, mob.sh is installed. https://mob.sh/"
+echo "View its website to learn more about how to use it for remote pairing/mobbing."
 
 echo
 echo "After checking the above output for any problems, start a new iTerm session to make use of all the installed tools."

--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -21,6 +21,9 @@ echo "export GIT_DUET_SET_GIT_USER_CONFIG=1" >> ~/.zshenv  # use regular git com
 echo "Putting a sample authors file in ~/.git-authors if it isn't already there"
 cp -n files/.git-authors ~/.git-authors || true
 
+echo "Installing pair/mob programming remote handover tools"
+brew install remotemobprogramming/brew/mob
+
 echo "Installing git UI tools"
 set +e # Optional; don't exit if they fail
 brew install --cask rowanj-gitx


### PR DESCRIPTION
## Proposal
Adopt [mob.sh](https://mob.sh/) within `workstation-setup` as a tool for facilitating handover between engineers during a remote pairing session.

## Background
Of the two primary forms of pairing (driver/navigator, ping pong), ping pong pairing does a good job of keeping both members of a pair active at the keyboard. Since the pandemic and the shift to remote pairing, it's become more difficult to rotate quickly, and many pairs have moved away from ping pong pairing. A few different tools have been created (both inside and outside of Labs) to help ease the pain of "handover" (ie, the process of shipping the current state of the code to the other person). [mob.sh](https://mob.sh/) is the most mature tool that I've seen that helps minimize the cost of handing off code between drivers in a remote pairing situation.

## How does it work?
[mob.sh](https://mob.sh/) manages the entire flow from creating a temporary git branch for development, to pushing code to that branch, to pulling the latest code, to preparing/rebasing/squashing all commits for commit/merge to a main trunk branch, to cleaning up temporary branches after they're no longer necessary. The process is as follows, assuming that two developers Carola and Maria are starting from a `main` branch:

```sh
# Carola
main $ mob start
mob/main $ echo "hello" > work.txt
mob/main $ mob next

# Maria
main $ mob start
mob/main $ cat work.txt # shows "hello"
mob/main $ echo " world" >> work.txt
mob/main $ mob next

# Carola
mob/main $ mob start
mob/main $ cat work.txt # shows "hello world"
mob/main $ echo "!" >> work.txt
mob/main $ mob done
main $ git commit -m "create greeting file"
main $ git push
```

The main commands used in the above flow are `mob start`, `mob next`, and `mob done`. Each one of these commands is making a few calls to git underneath the hood, and managing its state. (There's a video of this in action on the [mob.sh](https://mob.sh/) website, if you're curious about how it works.) The final step, `mob done`, will do a soft reset to the state before the first `mob start` was run, rebasing as necessary on the parent branch, so as to put the pair in good shape to run `git commit`.

Altogether, mob.sh is a fairly lightweight CLI tool that helps to minimize the friction of remote handover, thereby creating an environment in which pairs or mobs can adopt ping pong pairing more easily.