### PR TITLE
Remove/Update deprecated and deleted brew commands

### DIFF
--- a/scripts/common/configuration-osx.sh
+++ b/scripts/common/configuration-osx.sh
@@ -24,7 +24,7 @@ defaults -currentHost write com.apple.ImageCapture disableHotPlug -bool true
 # modify appearance of dock: remove standard icons, add chrome and iTerm
 if ! dockutil ; then
   # dockutil is not installed
-  brew install --cask hpedrorodrigues/tools/dockutil
+  brew install dockutil
 fi
 dockutil --list | awk -F\t '{print "dockutil --remove \""$1"\" --no-restart"}' | sh
 dockutil --add /Applications/Google\ Chrome.app --no-restart

--- a/scripts/common/git.sh
+++ b/scripts/common/git.sh
@@ -23,7 +23,7 @@ cp -n files/.git-authors ~/.git-authors || true
 
 echo "Installing git UI tools"
 set +e # Optional; don't exit if they fail
-brew install --cask rowanj-gitx
+brew install gitx
 brew install --cask sourcetree
 brew install --cask gitup
 set -e

--- a/scripts/common/homebrew.sh
+++ b/scripts/common/homebrew.sh
@@ -24,10 +24,6 @@ echo "Ensuring your Homebrew directory is writable..."
 sudo chown -Rf $(whoami) $(brew --prefix)/*
 
 echo
-echo "Installing Homebrew services..."
-brew tap homebrew/services
-
-echo
 echo "Adding Pivotal tap to Homebrew"
 brew tap pivotal/tap
 

--- a/scripts/opt-in/golang.sh
+++ b/scripts/opt-in/golang.sh
@@ -3,7 +3,6 @@ echo "Installing Golang Development tools"
 
 mkdir -p ~/go/src
 brew install go
-brew install dep
 brew install --cask goland
 
 #source ${MY_DIR}/scripts/common/download-jetbrains-ide-prefs.sh


### PR DESCRIPTION
Some quick fixes to allow workstation setup to run successfully:

- `dockutil` is now part of brew
- `gitx` is now part of brew. `rowan-gitx` is no longer available
- Brew services is no longer available. `brew services` are no part of brew
- `dep` was experimental and the Go community has moved away from it. `dep` is no longer available